### PR TITLE
Bug 1160913 - Use  /dev/urandom instead of /dev/random shorten the te…

### DIFF
--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -230,7 +230,7 @@ int random_pool_ready(void)
 	 * so use non-blocking read to avoid blocking the application
 	 * completely.
 	 */
-	fd = open("/dev/random", O_RDONLY | O_NONBLOCK);
+	fd = open("/dev/urandom", O_RDONLY | O_NONBLOCK);
 	if (fd < 0) {
 #ifndef CONFIG_NO_STDOUT_DEBUG
 		int error = errno;


### PR DESCRIPTION
…sting time. r=vchang.
